### PR TITLE
allow developer tools when app is packaged

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "reveal-editor",
     "productName": "reveal-editor",
-    "version": "0.0.1-alpha.13",
+    "version": "0.0.1-alpha.14",
     "description": "Editor to create presentations with Markdown and Reveal.js",
     "main": ".vite/build/main.js",
     "scripts": {

--- a/src-main/menu/menu.ts
+++ b/src-main/menu/menu.ts
@@ -96,9 +96,9 @@ export function buildTemplate(window: BrowserWindow): Electron.MenuItemConstruct
                     click: () => window.webContents.send('menu:reload-previews'),
                 },
                 { type: 'separator' },
-                ...(!app.isPackaged
-                    ? ([{ role: 'forceReload' }, { role: 'toggleDevTools' }, { type: 'separator' }] as const)
-                    : []),
+                { role: 'forceReload' },
+                { role: 'toggleDevTools' },
+                { type: 'separator' },
                 { role: 'resetZoom' },
                 { role: 'zoomIn' },
                 { role: 'zoomOut' },


### PR DESCRIPTION
- Maybe we can remove this again in a final release version, but for the moment I think it's very convenient to have this available also in a packaged version