### PR TITLE
Speedup Notarization

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -11,6 +11,8 @@ runs:
     - name: Publish Linux x64
       if: inputs.os == 'ubuntu-latest'
       shell: bash
+      env:
+        DEBUG: '@electron/get:*,electron-notarize*,electron-packager,get-package-info'
       run: >
         npm run publish 
         --
@@ -19,6 +21,8 @@ runs:
     - name: Publish Linux arm64
       if: inputs.os == 'ubuntu-latest'
       shell: bash
+      env:
+        DEBUG: '@electron/get:*,electron-notarize*,electron-packager,get-package-info'
       run: >
         npm run publish 
         --
@@ -27,6 +31,8 @@ runs:
     - name: Publish Linux armv7l
       if: inputs.os == 'ubuntu-latest'
       shell: bash
+      env:
+        DEBUG: '@electron/get:*,electron-notarize*,electron-packager,get-package-info'
       run: >
         npm run publish 
         --
@@ -42,6 +48,8 @@ runs:
     - name: Publish macOS x64
       if: inputs.os == 'macOS-latest'
       shell: bash
+      env:
+        DEBUG: '@electron/get:*,electron-notarize*,electron-osx-sign,electron-packager,get-package-info'
       run: >
         npm run publish
         --
@@ -50,6 +58,8 @@ runs:
     - name: Publish macOS arm64
       if: inputs.os == 'macOS-latest'
       shell: bash
+      env:
+        DEBUG: '@electron/get:*,electron-notarize*,electron-osx-sign,electron-packager,get-package-info'
       run: >
         npm run publish
         --
@@ -59,12 +69,16 @@ runs:
     - name: Setup Windows specific dependencies
       if: inputs.os == 'windows-latest'
       shell: bash
+      env:
+        DEBUG: '@electron/get:*,electron-notarize*,electron-packager,get-package-info'
       run: |
         npm install --save-dev exe-icon-extractor
         echo "${WIX}bin" >> $GITHUB_PATH
     - name: Publish Windows x64
       if: inputs.os == 'windows-latest'
       shell: bash
+      env:
+        DEBUG: '@electron/get:*,electron-notarize*,electron-packager,get-package-info'
       run: >
         npm run publish
         --
@@ -73,6 +87,8 @@ runs:
     - name: Publish Windows arm64
       if: inputs.os == 'windows-latest'
       shell: bash
+      env:
+        DEBUG: '@electron/get:*,electron-notarize*,electron-packager,get-package-info'
       run: >
         npm run publish
         --
@@ -81,6 +97,8 @@ runs:
     - name: Publish Windows ia32
       if: inputs.os == 'windows-latest'
       shell: bash
+      env:
+        DEBUG: '@electron/get:*,electron-notarize*,electron-packager,get-package-info'
       run: >
         npm run publish
         --

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -45,8 +45,10 @@ const macOSPackagerConfig = (): ForgePackagerOptions => {
     if (!process.env.CI) return {}
     if (process.platform !== 'darwin') return {}
 
-    if (!process.env.APPLE_ID || !process.env.APPLE_APP_SPECIFIC_PASSWORD) {
-        console.warn('Should be notarizing, but environment variables APPLE_ID or APPLE_ID_PASSWORD are missing!')
+    if (!process.env.APPLE_ID || !process.env.APPLE_APP_SPECIFIC_PASSWORD || !process.env.APPLE_TEAM_ID) {
+        console.warn(
+            'Should be notarizing, but environment variables APPLE_ID, APPLE_ID_PASSWORD or APPLE_TEAM_ID are missing!'
+        )
         return {}
     }
 
@@ -55,9 +57,10 @@ const macOSPackagerConfig = (): ForgePackagerOptions => {
             identity: process.env.MACOS_CERT_IDENTITY,
         },
         osxNotarize: {
+            tool: 'notarytool',
             appleId: process.env.APPLE_ID,
             appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
-            ascProvider: process.env.APPLE_TEAM_ID,
+            teamId: process.env.APPLE_TEAM_ID,
         },
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "reveal-editor",
-    "version": "0.0.1-alpha.15",
+    "version": "0.0.1-alpha.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "reveal-editor",
-            "version": "0.0.1-alpha.15",
+            "version": "0.0.1-alpha.16",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/commands": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "reveal-editor",
     "productName": "reveal-editor",
-    "version": "0.0.1-alpha.15",
+    "version": "0.0.1-alpha.16",
     "description": "Editor to create presentations with Markdown and Reveal.js",
     "main": ".vite/build/main.js",
     "scripts": {


### PR DESCRIPTION
- Use `notarytool` to notarize macOS app (which claims to be up to 10x faster 🤑)
- Display debug information for `publish` tasks